### PR TITLE
Fix the test for -t which was inverted

### DIFF
--- a/mbw.c
+++ b/mbw.c
@@ -210,8 +210,8 @@ int main(int argc, char **argv)
                 break;
             case 't': /* test to run */
                 testno=strtoul(optarg, (char **)NULL, 10);
-                if(0>testno) {
-                    printf("Error: test number must be between 0 and %d\n", MAX_TESTS);
+                if(testno>MAX_TESTS-1) {
+                    printf("Error: test number must be between 0 and %d\n", MAX_TESTS-1);
                     exit(1);
                 }
                 tests[testno]=1;


### PR DESCRIPTION
Found because GCC 6.4.0 emits a warning:

warning: comparison of 0 > unsigned expression is always false
[-Wtautological-compare]