### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(mbw VERSION 1.5)
+project(mbw VERSION 1.5 LANGUAGES C)
 
 add_executable(mbw mbw.c)
 install(TARGETS mbw DESTINATION bin)


### PR DESCRIPTION
Fix the following build failure without C++:

```
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

Fixes:
 - http://autobuild.buildroot.org/results/17e2d6e6d6ddf7845a37a8bbf733faf40d9faa61

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>