### PR TITLE
Removed unused header

### DIFF
--- a/mbw.c
+++ b/mbw.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
-#include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <time.h>


### PR DESCRIPTION
Nothing from `sys/mman.h` is used in the source.

Also, with this change the tool builds and works on Windows with MinGW. 